### PR TITLE
Corrected an error affecting Facebook profile picture not being shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * Tags: social avatar, avatar, gravatar, social
 * Requires at least: 3.3.1
 * Tested up to: 4.1
-* Stable tag: 1.4.1
+* Stable tag: 1.4.2
 * License: GPLv2 or later
 * License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -41,6 +41,10 @@ With Version 1.4 Cache functionality is implemented for Google Plus avatar, this
 
 ## Frequently Asked Questions
 No FAQS yet
+
+### Changelog
+#### 1.4.2
+* Fixed invalid url format for getting facebook profile picture
 
 ### Changelog
 #### 1.4.1 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: marutim
 Tags: social avatar, avatar, gravatar, social
 Requires at least: 3.3.1
 Tested up to: 4.1
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ No FAQS yet
 2. Profile Options screen
 
 == Changelog ==
+= 1.4.2 =
+* Fixed invalid url format for getting facebook profile picture
+
 = 1.4.1 =
 * Introduced wp_social_avatar_heading filter
 
@@ -67,4 +70,4 @@ No FAQS yet
 * First release.
 
 == Upgrade Notice ==
-1.4.1
+1.4.2


### PR DESCRIPTION
1. Fixed error regarding Facebook profile pictures not being shown due to wrong graph url format.:disappointed_relieved:
2. Bumped the version number from 1.4.1 to 1.4.2 based upon [semantic versioning](http://semver.org/).:wink:
